### PR TITLE
fix output dir bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm run test:e2e
 
 ### Run purescript tests
 ```
-npx spago test
+npm run test:purs
 ```
 
 ### Lints and fixes files
@@ -36,17 +36,15 @@ npx spago test
 npm run lint
 ```
 
+### Clean generated files
+```
+npm run clean
+```
+
+### Clean only purescript files
+```
+npm run clean:purs
+```
+
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).
-
-### FAQ
-
-```
-error  in ./src/index.purs
-
-Syntax Error: Error: compilation failed:
-From previous event:
-```
-- running spago test will produce `.spago` and `output/` which will cause errors for npm for some reason,
-- someone should investigate why
-- current workaround `npm run clean:purs`

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 // vue.config.js
 module.exports = {
   chainWebpack: (config) => {
@@ -9,11 +7,8 @@ module.exports = {
       .test(/\.purs$/)
       .use('purs-loader')
       .loader('purs-loader')
-      .tap(() => ({
-        src: [
-          path.join('src', '**', '*.purs'),
-          path.join('.spago', '**', 'src', '**', '*.purs'),
-        ],
-      }));
+      .options({
+        spago: true,
+      });
   },
 };


### PR DESCRIPTION
- you can now run `npm run test:purs` followed by `npm run serve` without any errors!!!