### PR TITLE
Separate diagram into own page

### DIFF
--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -18,7 +18,7 @@ nav.navbar.is-dark.mb-4
       @click='toggleNav',
       :class='showNav'
     )
-      .navbar-end
+      .navbar-start
         router-link.navbar-item(
           v-for='menu in menuItems',
           active-class='is-active',
@@ -33,6 +33,10 @@ export default {
       isNavActive: false,
       appName: 'Dolores',
       menuItems: [
+        {
+          name: 'Diagram',
+          link: '/diagram',
+        },
         /* {
           name: 'About',
           link: '/about',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,12 +1,18 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
 const rtHome = () => import('@/views/Home.vue');
+const rtDiagram = () => import('@/views/Diagram.vue');
 
 const routes = [
   {
     path: '/',
     name: 'Home',
     component: rtHome,
+  },
+  {
+    path: '/diagram',
+    name: 'Diagram',
+    component: rtDiagram,
   },
 ];
 

--- a/src/views/Diagram.vue
+++ b/src/views/Diagram.vue
@@ -5,22 +5,19 @@
       .title.is-spaced {{ questionPrompt }}
       .subtitle {{ responseMsg }}
   section.column
-    .block.has-text-left
-      Question(:question='questions', :depth=0)
-
+    .block
+      D3(:qroot='questions')
 </template>
 
 <script>
 import { mapGetters } from 'vuex';
 import { mapFields } from 'vuex-map-fields';
 import Notification from '@/components/questions/Notification.vue';
-import Question from '@/components/questions/Question.vue';
 import D3 from '@/components/viz/D3.vue';
 
 export default {
   name: 'Home',
   components: {
-    Question,
     Notification,
     D3,
   },


### PR DESCRIPTION
Improve the usability of the application by avoiding having the diagram stacking on top of the questions.

## Changes

### Added
- New page using `Diagram.vue`

### Changed
- Removed D3 block from home page which was then incorporated in `Diagram.vue`
- Move top navbar starting position to the left
- Add link to `Diagram.vue`