### PR TITLE
Orderedmap becomes hashmap

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -108,7 +108,7 @@ in  upstream
       [ "effect"
       , "foreign"
       , "foreign-object"
-      , "ordered-collections"
+      , "unordered-collections"
       , "exceptions"
       , "record"
       , "identity"

--- a/src/AnyAll.purs
+++ b/src/AnyAll.purs
@@ -37,7 +37,7 @@ import AnyAll.Relevance (relevant)
 import RuleLib.PDPADBNO as RuleLib.PDPADBNO
 
 import Partial.Unsafe
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.Either (Either(..), fromRight, either)
 import Data.Maybe (Maybe(..), fromJust)
 import Data.Tuple (Tuple(..))

--- a/src/AnyAll/Relevance.purs
+++ b/src/AnyAll/Relevance.purs
@@ -3,7 +3,6 @@ module AnyAll.Relevance where
 import AnyAll.Types
 import Prelude
 
-import Data.Set as Set
 import Data.Tuple
 import Data.HashMap as Map
 import Data.List (any, all, elem, List(..))
@@ -38,7 +37,7 @@ relevant sh dp marking parentValue nl self =
   -- to a dictionary of { langID: longtext }
   nlMap word nldict =
     let
-      langs = Set.toUnfoldable $ Map.keys nldict :: Array String
+      langs = Map.keys nldict
     in
       Map.fromFoldable $ do
         lg <- langs

--- a/src/AnyAll/Relevance.purs
+++ b/src/AnyAll/Relevance.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Data.Set as Set
 import Data.Tuple
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.List (any, all, elem, List(..))
 import Data.Foldable (class Foldable)
 

--- a/src/AnyAll/Types.purs
+++ b/src/AnyAll/Types.purs
@@ -12,7 +12,6 @@ import Data.Maybe
 import Data.String
 import Data.String as DString
 import Data.Symbol
-import Data.Hashable
 import Data.HashMap as Map
 import Option as Option
 import Simple.JSON as JSON

--- a/src/AnyAll/Types.purs
+++ b/src/AnyAll/Types.purs
@@ -12,7 +12,8 @@ import Data.Maybe
 import Data.String
 import Data.String as DString
 import Data.Symbol
-import Data.Map as Map
+import Data.Hashable
+import Data.HashMap as Map
 import Option as Option
 import Simple.JSON as JSON
 
@@ -94,13 +95,13 @@ label2pre (PrePost x y) = x
 label2post (PrePost x y) = y
 label2post (Pre x) = "" -- maybe throw an error?
 
-type NLDict = Map.Map String (Map.Map String String)
+type NLDict = Map.HashMap String (Map.HashMap String String)
 
 -- an Item tree represents the logic. The logic is immutable, at least within the short-term lifetime of a user session.
 -- By contrast, a Marking contains the current state of which elements have received user input;
 -- if no user input was received, the Marking gives default values. This gets updated every time the user clicks something.
 
-newtype Marking = Marking (Map.Map String (Default Bool))
+newtype Marking = Marking (Map.HashMap String (Default Bool))
 
 derive instance eqMarking :: Eq (Marking)
 derive instance genericMarking :: Generic Marking _
@@ -132,7 +133,7 @@ readDefault fm mk = do
         _ -> Nothing
   pure $ Tuple mk (lr mb)
 
-markup :: Map.Map String (Either (Maybe Boolean) (Maybe Boolean)) -> Marking
+markup :: Map.HashMap String (Either (Maybe Boolean) (Maybe Boolean)) -> Marking
 markup x = Marking $ Default <$> x
 
 getMarking (Marking mymap) = mymap
@@ -163,7 +164,7 @@ type DefaultRecord =
 newtype Q = Q
   { shouldView :: ShouldView
   , andOr :: AndOr String
-  , tagNL :: Map.Map String String
+  , tagNL :: Map.HashMap String String
   , prePost :: Maybe (Label String)
   , mark :: Default Bool
   , children :: Array Q
@@ -177,7 +178,7 @@ instance showQ :: Show (Q) where
 type R =
   { shouldView :: ShouldView
   , andOr :: AndOr String
-  , tagNL :: Map.Map String String
+  , tagNL :: Map.HashMap String String
   , prePost :: Maybe (Label String)
   , mark :: Default Bool
   }
@@ -328,13 +329,13 @@ getSV sv1 (Q sv2 (Simply x) pp m)
   | otherwise  = Nothing
 getSV _ _ = Nothing
 
-getAsks :: (ToJSONKey a, Ord a) => QTree a -> Map.Map a (Default Bool)
+getAsks :: (ToJSONKey a, Ord a) => QTree a -> Map.HashMap a (Default Bool)
 getAsks qt = Map.fromList $ catMaybes $ getSV Ask <$> flatten qt
 
 getAsksJSON :: (ToJSONKey a, Ord a) => QTree a -> B.ByteString
 getAsksJSON = encode . getAsks
 
-getViews :: (ToJSONKey a, Ord a) => QTree a -> Map.Map a (Default Bool)
+getViews :: (ToJSONKey a, Ord a) => QTree a -> Map.HashMap a (Default Bool)
 getViews qt = Map.fromList $ catMaybes $ getSV View <$> flatten qt
 
 getViewsJSON :: (ToJSONKey a, Ord a) => QTree a -> B.ByteString

--- a/src/AnyAll/Types.purs
+++ b/src/AnyAll/Types.purs
@@ -107,7 +107,7 @@ derive instance eqMarking :: Eq (Marking)
 derive instance genericMarking :: Generic Marking _
 derive newtype instance showMarking :: Show (Marking)
 instance encodeMarking :: Encode Marking where
-  encode (Marking mymap) = unsafeToForeign $ FO.fromFoldable (Map.toUnfoldable (dumpDefault <$> mymap) :: List _)
+  encode (Marking mymap) = unsafeToForeign $ FO.fromFoldable $ Map.toArrayBy Tuple $ (dumpDefault <$> mymap)
 
 -- should this be decodeMarking?
 instance decodeMarking :: Decode Marking where
@@ -239,7 +239,7 @@ qoutjs (Q q@{ shouldView, andOr, tagNL, prePost, mark, children }) =
     }
   where
   miniNL =
-    FO.fromFoldable (Map.toUnfoldable tagNL :: Array (Tuple String String))
+    FO.fromFoldable (Map.toArrayBy Tuple tagNL :: Array (Tuple String String))
 
 newtype PrePostRecord = PPR (Option.Option (pre :: String, post :: String))
 

--- a/src/RuleLib/Interview.purs
+++ b/src/RuleLib/Interview.purs
@@ -4,7 +4,7 @@
 -- Do not edit by hand.
 -- Instead, revise the toolchain starting at smucclaw/dsl/lib/haskell/natural4/app/Main.hs
 
-module RuleLib.PDPADBNO where
+module RuleLib.Interview where
 
 import Prelude
 import Data.Either

--- a/src/RuleLib/PDPADBNO.purs
+++ b/src/RuleLib/PDPADBNO.purs
@@ -10,7 +10,7 @@ import Prelude
 import Data.Either
 import Data.Maybe
 import Data.Tuple
-import Data.Map as Map
+import Data.HashMap as Map
 import Foreign.Object as Object
 
 import AnyAll.Types

--- a/tests/purescript/AnyAll/PdpaQ.purs
+++ b/tests/purescript/AnyAll/PdpaQ.purs
@@ -1,7 +1,7 @@
 module AnyAll.PdpaQ where
 
 import AnyAll.Types
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Data.Either (Either(..))

--- a/tests/purescript/AnyAll/Relevance.purs
+++ b/tests/purescript/AnyAll/Relevance.purs
@@ -6,7 +6,7 @@ import Effect.Exception (Error)
 import Test.Spec (SpecT, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import AnyAll.Types (Default(..), Hardness(..), Item(..), Label(..), Marking(..))
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.Tuple (Tuple(..))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))

--- a/tests/purescript/AnyAll/Rendering.purs
+++ b/tests/purescript/AnyAll/Rendering.purs
@@ -10,7 +10,7 @@ import AnyAll.Relevance (relevant)
 import RuleLib.PDPADBNO as RuleLib.PDPADBNO
 
 import Partial.Unsafe (unsafeCrashWith)
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))

--- a/tests/purescript/AnyAll/ViewHide.purs
+++ b/tests/purescript/AnyAll/ViewHide.purs
@@ -5,7 +5,7 @@ import Control.Monad.Error.Class (class MonadThrow)
 import Effect.Exception (Error)
 import Test.Spec (SpecT, describe, it)
 import Test.Spec.Assertions (shouldEqual)
-import Data.Map as Map
+import Data.HashMap as Map
 import Data.Tuple (Tuple(..))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))


### PR DESCRIPTION
Change ordered maps of string keys to hashmaps of string keys because string comparisons are pricy, which adds up if you have to do log2(n) of them while traversing down the tree.